### PR TITLE
PCHR-3682: Custom database configuration

### DIFF
--- a/civihr.install
+++ b/civihr.install
@@ -135,6 +135,13 @@ function civihr_install() {
   variable_set('node_admin_theme', '1');
 }
 
+/**
+ * Implements hook_install_tasks and define the custom tasks used by this profile
+ *
+ * @param array $install_state
+ *
+ * @return mixed
+ */
 function civihr_install_tasks($install_state) {
   $tasks['install_civihr'] = [
     'type' => 'batch',
@@ -153,6 +160,13 @@ function civihr_install_tasks($install_state) {
   return $tasks;
 }
 
+/**
+ * Implements hook_install_tasks_alter and makes customizations to the default
+ * tasks configuration
+ *
+ * @param array $tasks
+ * @param array $install_state
+ */
 function civihr_install_tasks_alter(&$tasks, $install_state) {
   $tasks['install_select_profile']['display'] = FALSE;
   // Hide and skip the default database configuration step, as we have our own
@@ -171,6 +185,15 @@ function civihr_install_tasks_alter(&$tasks, $install_state) {
   $tasks = array_slice($old_tasks, 0, 4) + $new_task + array_slice($old_tasks, 4);
 }
 
+/**
+ * Function that executes the install_civihr task.
+ *
+ * It is basically a set of batch jobs that will do the entire CiviHR installation,
+ * which includes: installing and configuring CiviCRM, the CiviHR extensions and
+ * the SSP modules
+ *
+ * @return array
+ */
 function _civihr_install_civihr() {
   $operations = [];
   $operations[] = [ '_civihr_install_civicrm', [] ];
@@ -185,6 +208,13 @@ function _civihr_install_civihr() {
   ];
 }
 
+/**
+ * Installs CiviCRM
+ *
+ * @param array $context
+ *
+ * @throws \Exception
+ */
 function _civihr_install_civicrm(&$context) {
   global $databases;
 
@@ -223,6 +253,11 @@ function _civihr_install_civicrm(&$context) {
   watchdog(WATCHDOG_INFO, 'CiviCRM Installed');
 }
 
+/**
+ * Create a set of batch operations to install the CiviHR extensions
+ *
+ * @return array
+ */
 function _civihr_get_extension_install_operations() {
   $operations = [];
 
@@ -269,6 +304,14 @@ function _civihr_get_extension_install_operations() {
   return $operations;
 }
 
+/**
+ * Installs the given $extensions in CiviCRM.
+ *
+ * @param array $extensions
+ * @param array $context
+ *
+ * @throws \CiviCRM_API3_Exception
+ */
 function  _civihr_install_install_extensions($extensions, &$context) {
   civicrm_initialize();
   $context['message'] = 'Installed ' . implode(', ', $extensions);
@@ -281,6 +324,12 @@ function  _civihr_install_install_extensions($extensions, &$context) {
   watchdog(WATCHDOG_INFO, 'Installed ' . implode(', ', $extensions));
 }
 
+/**
+ * Executes the SSP installation, which involves enabling all the necessary
+ * modules and features, as well as doing all the required drupal configuration.
+ *
+ * @param array $context
+ */
 function _civihr_install_ssp(&$context) {
   watchdog(WATCHDOG_INFO, 'Install SSP');
   _civihr_enabled_ssp_modules_and_features();
@@ -289,6 +338,9 @@ function _civihr_install_ssp(&$context) {
   watchdog(WATCHDOG_INFO, 'SSP Installed');
 }
 
+/**
+ * Enables all the modules and features used in the SSP
+ */
 function _civihr_enabled_ssp_modules_and_features() {
   watchdog(WATCHDOG_INFO, 'Installing SSP modules and features');
   drupal_flush_all_caches();
@@ -328,6 +380,9 @@ function _civihr_enabled_ssp_modules_and_features() {
   drupal_flush_all_caches();
 }
 
+/**
+ * Do any necessary Drupal configuration for the SSP
+ */
 function _civihr_ssp_extra_configuration() {
   watchdog(WATCHDOG_INFO, 'SSP extra configuration');
   variable_set('logintoboggan_login_with_email', 1);
@@ -340,6 +395,9 @@ function _civihr_ssp_extra_configuration() {
   drupal_flush_all_caches();
 }
 
+/**
+ * Setup the SSP themes
+ */
 function _civihr_setup_themes() {
   watchdog(WATCHDOG_INFO, 'Setup SSP themes');
   theme_enable(['seven', 'civihr_default_theme']);
@@ -350,6 +408,9 @@ function _civihr_setup_themes() {
   variable_set('civicrmtheme_theme_public', 'seven');
 }
 
+/**
+ * Creates the CiviHR demo users (civihr_staff, civihr_manager and civihr_admin)
+ */
 function _civihr_setup_users() {
   $users = [
     [
@@ -374,6 +435,13 @@ function _civihr_setup_users() {
   }
 }
 
+/**
+ * Creates a Drupal user and assign it to the given $roles
+ *
+ * @param string $username
+ * @param string $email
+ * @param array $roles
+ */
 function _civihr_create_user($username, $email, $roles = []) {
   $user = new stdClass();
   $user->roles = _civihr_get_roles($roles);
@@ -386,6 +454,15 @@ function _civihr_create_user($username, $email, $roles = []) {
   ]);
 }
 
+/**
+ * Returns a list of IDs for the given roles.
+ *
+ * The list format is: [ 'id' => 'role' ]
+ *
+ * @param array $roles
+ *
+ * @return array
+ */
 function _civihr_get_roles($roles) {
   $userRoles = array_flip(user_roles());
 
@@ -399,6 +476,12 @@ function _civihr_get_roles($roles) {
   return $ids;
 }
 
+/**
+ * Function called as the last of all the install tasks and it can be used by
+ * any sort of cleanup work
+ *
+ * @throws \Exception
+ */
 function _civihr_finish_civihr_installation() {
   global $databases;
 
@@ -413,6 +496,11 @@ function _civihr_finish_civihr_installation() {
   drupal_rewrite_settings($settings);
 }
 
+/**
+ * The form used by the Database Configuration task
+ *
+ * @return array
+ */
 function database_configuration() {
   $form = [];
 
@@ -489,6 +577,12 @@ function database_configuration() {
   return $form;
 }
 
+/**
+ * Validates the database configuration form
+ *
+ * @param array $form
+ * @param array $form_state
+ */
 function database_configuration_validate($form, &$form_state) {
   $values = $form_state['values'];
   if ($values['drupal']['database'] === $values['civicrm']['database']) {
@@ -496,12 +590,20 @@ function database_configuration_validate($form, &$form_state) {
   }
 }
 
+/**
+ * Function called when the database configuration form is submitted
+ *
+ * @param array $form
+ * @param array $form_state
+ *
+ * @throws \Exception
+ */
 function database_configuration_submit($form, &$form_state) {
   global $install_state;
 
   $form_values = $form_state['values'];
 
-  // Adapted from install_settings_form_submit()
+  // Settings saving adapted from install_settings_form_submit()
   $additionalDatabaseSettings = [
     'host' => $form_values['advanced']['host'] ?: '127.0.0.1',
     'port' => $form_values['advanced']['port'] ?: '3306',

--- a/civihr.install
+++ b/civihr.install
@@ -142,11 +142,33 @@ function civihr_install_tasks($install_state) {
     'function' => '_civihr_install_civihr'
   ];
 
+  $tasks['finish_civihr_configuration'] = [
+    'display' => FALSE,
+    'display_name' => st('Finish CiviHR configuration'),
+    'type' => 'normal',
+    'run' => INSTALL_TASK_RUN_IF_REACHED,
+    'function' => '_civihr_finish_civihr_installation'
+  ];
+
   return $tasks;
 }
 
 function civihr_install_tasks_alter(&$tasks, $install_state) {
   $tasks['install_select_profile']['display'] = FALSE;
+  // Hide and skip the default database configuration step, as we have our own
+  $tasks['install_settings_form']['run'] = INSTALL_TASK_SKIP;
+  $tasks['install_settings_form']['display'] = FALSE;
+
+  $new_task['database_configuration'] = array(
+    'display' => TRUE,
+    'display_name' => st('Database Configuration'),
+    'type' => 'form',
+    'run' => isset($install_state['parameters']['database_configured']) ? INSTALL_TASK_SKIP : INSTALL_TASK_RUN_IF_REACHED,
+  );
+
+  // Add our database configuration step after the Verify Requirements step
+  $old_tasks = $tasks;
+  $tasks = array_slice($old_tasks, 0, 4) + $new_task + array_slice($old_tasks, 4);
 }
 
 function _civihr_install_civihr() {
@@ -164,6 +186,12 @@ function _civihr_install_civihr() {
 }
 
 function _civihr_install_civicrm(&$context) {
+  global $databases;
+
+  if (empty($databases['civicrm']['default'])) {
+    throw new \Exception('The CiviCRM database configuration is missing');
+  }
+
   watchdog(WATCHDOG_INFO, 'Installing CiviCRM');
   $civicrm_path = dirname(drupal_get_path('module', 'civicrm'));
 
@@ -181,11 +209,12 @@ function _civihr_install_civicrm(&$context) {
   // db property, so this is why we can only set it after we instantiate the
   // setup object.
   // @TODO use the init() method when this PR gets merged: https://github.com/civicrm/civicrm-setup/pull/14
+  $civicrmDb = $databases['civicrm']['default'];
   $setup->getModel()->db = [
-    'server' => 'localhost:3306',
-    'username' => 'root',
-    'password' => 'root',
-    'database' => 'civihr_civicrm'
+    'server' => "{$civicrmDb['host']}:{$civicrmDb['port']}",
+    'username' => $civicrmDb['username'],
+    'password' => $civicrmDb['password'],
+    'database' => $civicrmDb['database']
   ];
 
   $setup->installFiles();
@@ -368,4 +397,145 @@ function _civihr_get_roles($roles) {
   }
 
   return $ids;
+}
+
+function _civihr_finish_civihr_installation() {
+  global $databases;
+
+  // Now that we have CiviCRM installed with its own settings file we can remove
+  // the configuration from the Drupal settings file
+  $newDatabasesConfiguration = $databases;
+  unset($newDatabasesConfiguration['civicrm']);
+  $settings['databases'] = [
+    'value' => $newDatabasesConfiguration,
+    'required' => TRUE,
+  ];
+  drupal_rewrite_settings($settings);
+}
+
+function database_configuration() {
+  $form = [];
+
+  $form['database_configuration']['drupal'] = [
+    '#title' => 'Drupal Database',
+    '#type' => 'fieldset',
+    '#tree' => TRUE,
+  ];
+
+  $form['database_configuration']['drupal']['database'] = [
+    '#title' => st('Database'),
+    '#type' => 'textfield',
+    '#required' => TRUE,
+  ];
+
+  $form['database_configuration']['drupal']['username'] = [
+    '#title' => st('Username'),
+    '#type' => 'textfield',
+    '#required' => TRUE,
+  ];
+
+  $form['database_configuration']['drupal']['password'] = [
+    '#title' => st('Password'),
+    '#type' => 'password'
+  ];
+
+  $form['database_configuration']['civicrm'] = [
+    '#title' => 'CiviCRM Database',
+    '#type' => 'fieldset',
+    '#tree' => TRUE,
+  ];
+
+  $form['database_configuration']['civicrm']['database'] = [
+    '#title' => st('Database'),
+    '#type' => 'textfield',
+    '#required' => TRUE,
+  ];
+
+  $form['database_configuration']['civicrm']['username'] = [
+    '#title' => st('Username'),
+    '#type' => 'textfield',
+    '#required' => TRUE,
+  ];
+
+  $form['database_configuration']['civicrm']['password'] = [
+    '#title' => st('Password'),
+    '#type' => 'password'
+  ];
+
+  $form['database_configuration']['advanced'] = [
+    '#title' => 'Advanced Configuration',
+    '#type' => 'fieldset',
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#tree' => TRUE,
+  ];
+
+  $form['database_configuration']['advanced']['host'] = [
+    '#title' => 'Host',
+    '#type' => 'textfield',
+  ];
+
+  $form['database_configuration']['advanced']['port'] = [
+    '#title' => 'Port',
+    '#type' => 'textfield',
+  ];
+
+  $form['actions'] = ['#type' => 'actions'];
+  $form['actions']['save'] = [
+    '#type' => 'submit',
+    '#value' => st('Save and continue'),
+  ];
+
+  return $form;
+}
+
+function database_configuration_validate($form, &$form_state) {
+  $values = $form_state['values'];
+  if ($values['drupal']['database'] === $values['civicrm']['database']) {
+    form_set_error('civicrm][database', st('The CiviCRM database cannot be the same as the Drupal database'));
+  }
+}
+
+function database_configuration_submit($form, &$form_state) {
+  global $install_state;
+
+  $form_values = $form_state['values'];
+
+  // Adapted from install_settings_form_submit()
+  $additionalDatabaseSettings = [
+    'host' => $form_values['advanced']['host'] ?: '127.0.0.1',
+    'port' => $form_values['advanced']['port'] ?: '3306',
+    'driver' => 'mysql',
+    'prefix' => ''
+  ];
+
+  $settings['databases'] = [
+    'value'    => [
+      'default' => [
+        'default' => array_merge($form_values['drupal'], $additionalDatabaseSettings)
+      ],
+      // At this point, neither the session nor the database are initialized yet,
+      // so, in order to make this configuration available to the CiviCRM installation
+      // step, we save it to the Drupal settings file and then erase it once the
+      // CiviCRM settings file is created
+      'civicrm' => [
+        'default' => array_merge($form_values['civicrm'], $additionalDatabaseSettings)
+      ]
+    ],
+    'required' => TRUE,
+  ];
+  $settings['drupal_hash_salt'] = array(
+    'value'    => drupal_random_key(),
+    'required' => TRUE,
+  );
+  $settings['ski'] = array(
+    'value'    => drupal_random_key(),
+    'required' => TRUE,
+  );
+
+  drupal_rewrite_settings($settings);
+
+  $install_state['parameters']['database_configured'] = true;
+  $install_state['settings_verified'] = TRUE;
+  $install_state['completed_task'] = install_verify_completed_task();
 }


### PR DESCRIPTION
### Problem

The default Drupal installation has one step where it is possible to configure the database:

![captura de tela de 2018-05-23 17-07-55](https://user-images.githubusercontent.com/388373/40448432-e3b8e246-5eab-11e8-9b98-2c67640e7658.png)

For CiviHR, however, we also need to configure the CiviCRM database. Until now, this configuration was [hardcoded](https://github.com/compucorp/civihr-profile/blob/49a78ac3e21639e278c2bef35d82d14dab23f96d/civihr.install#L184-L189).

### Solution

This PR addresses the problem by customizing the installation process with a custom Database Configuration screen where it is possible to configure the two necessary databases and allows us to remove the hardcoded configuration for CiviCRM.

This is the new configuration screen:

![captura de tela de 2018-05-23 17-14-37](https://user-images.githubusercontent.com/388373/40448748-d0495b0e-5eac-11e8-9a91-cbe11a977976.png)

The "Drupal Database" and the "CiviCRM Database" sections are self-descriptive. In the "Advanced Configuration", users can specify a host and port to be used in the database connection:

![captura de tela de 2018-05-23 17-18-48](https://user-images.githubusercontent.com/388373/40448945-62afd55e-5ead-11e8-969c-7d1134e05f33.png)

There's only one "Advanced Configuration" panel because both databases should be installed in the same host. This is due to the database views we have in the SSP that access data from the CiviCRM database.

Finally, note that the entire installation profile is in a very initial phase. Right now we are still in a "make it work" stage and this is the reason the custom configuration form looks so simple. In a later stage it will be revisited and we'll probably add more instructions and more helpful information to it.
