### PR TITLE
PCHR-3683: Optionally create demo users

### DIFF
--- a/civihr.install
+++ b/civihr.install
@@ -412,6 +412,10 @@ function _civihr_setup_themes() {
  * Creates the CiviHR demo users (civihr_staff, civihr_manager and civihr_admin)
  */
 function _civihr_setup_users() {
+  if (!variable_get('civihr_create_demo_users', false)) {
+    return;
+  }
+
   $users = [
     [
       'username' => 'civihr_staff',
@@ -484,6 +488,10 @@ function _civihr_get_roles($roles) {
  */
 function _civihr_finish_civihr_installation() {
   global $databases;
+
+  // We only use this variable during the installation, so there's no reason to
+  // keep it now that everything is installed
+  variable_del('civihr_create_demo_users');
 
   // Now that we have CiviCRM installed with its own settings file we can remove
   // the configuration from the Drupal settings file
@@ -640,4 +648,44 @@ function database_configuration_submit($form, &$form_state) {
   $install_state['parameters']['database_configured'] = true;
   $install_state['settings_verified'] = TRUE;
   $install_state['completed_task'] = install_verify_completed_task();
+}
+
+/**
+ * Implements hook_form_alter to modify the install_configure_form and add
+ * options specific to the CiviHR installation
+ *
+ * @param array $form
+ * @param array $form_state
+ */
+function civihr_form_install_configure_form_alter(&$form, &$form_state) {
+  $form['demo_data'] = [
+    '#type' => 'fieldset',
+    '#title' => 'Demo Data',
+  ];
+
+  $form['demo_data']['create_demo_users'] = [
+    '#type' => 'checkbox',
+    '#title' => 'Create demo users',
+    '#description' => t('If selected, the system will create three users (civihr_staff, civihr_manager, and civihr_admin), so that you can try it out using different roles'),
+    '#default_value' => 1
+  ];
+
+  // When the custom submit function is added, the default one is lost and it is
+  // not called, so here we add first the default one and then our custom function
+  $form['actions']['submit']['#submit'][] = 'install_configure_form_submit';
+  $form['actions']['submit']['#submit'][] = 'civihr_install_configure_form_submit';
+}
+
+/**
+ * Custom handler for the install_configure_form submission. Basically, this
+ * takes care of handling any custom fields added to that form by this profile
+ *
+ * @param $form
+ * @param $form_state
+ */
+function civihr_install_configure_form_submit($form, &$form_state) {
+  variable_set(
+    'civihr_create_demo_users',
+    !empty($form_state['values']['create_demo_users'])
+  );
 }

--- a/civihr.install
+++ b/civihr.install
@@ -638,11 +638,6 @@ function database_configuration_submit($form, &$form_state) {
     'value'    => drupal_random_key(),
     'required' => TRUE,
   );
-  $settings['ski'] = array(
-    'value'    => drupal_random_key(),
-    'required' => TRUE,
-  );
-
   drupal_rewrite_settings($settings);
 
   $install_state['parameters']['database_configured'] = true;


### PR DESCRIPTION
### Problem

Currently, in addition to the admin superuser, the installation also creates 3 demo users: civihr_staff, civihr_manager, and civihr_admin. Each one assigned to a different role, so that people interested in trying the system out can easily see how it works from the point of view of people in different levels.

Although this is useful for people just trying to test CiviHR, it can be problematic for people that actually want to use the system as it is likely that they won't need any of these users and they will have to manually remove them.

### Solution

The site configuration form was customized with a new "Demo Data" section. Inside it, there's a "Create demo users" option which can be used to tell the installation process to create or not the demo users. The option is selected by default, as the default behavior in the existing CiviHR installation scripts is to create these users.

![configure site drupal](https://user-images.githubusercontent.com/388373/40560522-ac020fd6-6030-11e8-99e5-604ae66424bd.png)

### Comments

This PR also includes a commit (e19e7b6) that is not really related to this change and only removes an unused setting.