### PR TITLE
PCHR-3681: Migrate all the functionality in the bash installation script to the profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,117 @@
+## Introduction
+
+This Drupal profile was created to make the CiviHR installation as easy and simple as possible. In this repo, you'll find two pieces that are responsible for making this happen:
+
+- The `civihr.make.yml` file, which lists all of the CiviHR dependencies and makes it possible to download everything with a simple `drush make` command
+- The profile itself (`civihr.profile`, `civihr.module`, `civihr.info` and the `civihr.install` files), which is responsible to encapsulate all the logic necessary to setup the site which was built using the make file.
+
+> **What is a Drupal profile?**
+> 
+> A profile is a special type of Drupal module that hook into the Drupal site installation, allowing the module to perform various setup/configuration tasks while the site is being installed. Here is a list of some of the things the CiviHR profile does:
+> 
+> - Make sure only the blocks, node types and vocabularies used by CiviHR are created
+> - Optionally create demo users, that can be used by people who only want to try CiviHR out
+> - Make sure all the dependencies are installed in the correct order
+> - Set up all the necessary themes
+>
+> The profile also makes it possible to install CiviHR using your browser, via a web interface, instead of using the `drush site-install` command.
+> 
+> For more information about Drupal profiles, please check the [official documentation](https://www.drupal.org/docs/7/creating-distributions).
+
+## Requirements
+
+- Drush 8.x
+
+## Usage
+
+### Downloading dependencies
+
+First, you'll need to create a new site by downloading all the dependencies. To do that, you can use the `build-dist.sh` script:
+
+```
+$ ./build-dist.sh
+```
+
+That script, will basically run this `drush make` command:
+
+```
+drush make build-civihr-package.make.yml site
+```
+
+Which will result in a new CiviHR site built in the `site` folder. This site is now ready to be installed.
+
+> **Why `build-civihr-package.make.yml` instead of `civihr.make.yml`?**
+> 
+> The `civihr.make.yml` file contains only the CiviHR dependencies. The `build-civihr-package.make.yml` file, contains the "definition" of a CiviHR site, which is a Drupal site + the CiviHR profile (that includes all of the CiviHR dependecies).
+>
+> In practical terms, if you run `drush make civihr.make.yml`, all the dependencies will be downloaded, but the site will not include the CiviHR profile and it will not be possible to proceed with the installation. Differently, when using `build-civihr-package.make.yml`, the site will also include the profile, which will make it possible to go ahead with the installation.
+
+#### Downloading dependencies for a development site
+
+The CiviHR code is kept in multiple different git repositories. When downloading that code, the `build-dist.sh` script will make a shallow copy of these repos. That is, it will only download the latest version of the code available instead of creating a working copy of the repository. This is great for people that only want to use CiviHR, as it will drastically reduce the download size, but it's not ideal for developers. 
+
+To create a development site, the `build-dev.sh` should be used instead. It executes a `drush make` command very similar to the one used by the `build-dist.sh` script, but it will use the `civihr-dev.make.yml` to override some options in the original make file, and tell the make command to create working copies while cloning the repos.
+
+### Installing the site
+
+Now that you have all the dependencies in place, you can go ahead with the installation, which can be done either via a web interface or using `drush site-install`.
+
+### Installation using `drush site-install`
+
+For this installation method, you'll first need to manually create an empty database which will be used by CiviCRM. With that done, you can run the `site-install` command:
+
+```
+$ drush site-install -y civihr --locale=en \
+--db-url=mysql://<db_user>:<db_password>@<db_host>:<db_port>/<drupal_db_name> \
+--account-name="<super admin username>" \
+--account-pass="<super admin password>" \
+--account-mail="<super admin email>" \
+--site-name="<site name>" \
+database_configuration.drupal.database=<drupal_db_name> \
+database_configuration.drupal.username=<db_user> \
+database_configuration.drupal.password=<db_user> \
+database_configuration.civicrm.database=<civicrm_db_name> \
+database_configuration.civicrm.username=<db_user> \
+database_configuration.civicrm.password=<db_user>
+```
+
+Notes:
+- The CiviCRM database cannot be the same database as Drupal's.
+- Both databases must be in the same host
+- It's possible to have a different user for each database, but both users must have access to both databases.
+
+Here is an example:
+
+```
+$ drush site-install -y civihr --locale=en \
+--db-url=mysql://root:root@127.0.0.1:3306/civihr_drupal \
+--account-name="admin" \
+--account-pass="admin" \
+--account-mail="admin@example.org" \
+--site-name="CiviHR" \
+database_configuration.drupal.database=civihr_drupal \
+database_configuration.drupal.username=root \
+database_configuration.drupal.password=root \
+database_configuration.civicrm.database=civihr_civicrm \
+database_configuration.civicrm.username=root \
+database_configuration.civicrm.password=root
+```
+
+> **Important**
+>
+> You MUST execute the `site-install` command from the site root folder. If you've created the site using one of the bash scripts in this repo, that folder will be `site`.
+
+### Installation using the web-interface
+
+For this method, you'll need to have a virtual host in your webserver pointing to the site you've created with the make command. It's out of the scope of this documentation to describe how to configure your webserver, but keep in mind that you'll need URL rewriting enabled.
+
+Besides the webserver configuration, it is also necessary to manually create two empty databases: one for Drupal and another one for CiviCRM.
+
+With everything ready, all you'll have to do is point your browser to the configured website and you'll see an installation wizard very similar to the regular Drupal one. Follow each of the steps and, at the end, you'll have a working site.
+
+## Known issues and limitations
+
+- Regardless of the installation method, the CiviCRM database needs to be manually created.
+- There's some duplication in the drupal database params passed to the `site-install` command.
+- The `build-dev.sh` script uses a tarball to download CiviCRM. This results in a site that is not 100% suitable for development, as the tarball misses some classes and scripts necessary for our development workflow
+- It is not possible to tell `build-dev.sh` which branch it should download the code from. This happens because it builds the site based on the dependencies in the .yml file and it's not possible to pass params to it.

--- a/build-dev.sh
+++ b/build-dev.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-drush make build-civihr-package.make.yml site --overrides=civihr-dev.make.yml --contrib-destination=profiles/civihr
+drush make --concurrency=5 build-civihr-package.make.yml site --overrides=civihr-dev.make.yml --contrib-destination=profiles/civihr

--- a/build-dist.sh
+++ b/build-dist.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-drush make build-civihr-package.make.yml site
+drush make --concurrency=5 build-civihr-package.make.yml site

--- a/civihr.install
+++ b/civihr.install
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\civihr_employee_portal\Helpers\NodeHelper;
+
 /**
  * Implements hook_install()
  */
@@ -336,6 +338,7 @@ function _civihr_install_ssp(&$context) {
   _civihr_enabled_ssp_modules_and_features();
   _civihr_setup_themes();
   _civihr_setup_users();
+  _civihr_import_export_node_files();
   watchdog(WATCHDOG_INFO, 'SSP Installed');
 }
 
@@ -479,6 +482,15 @@ function _civihr_get_roles($roles) {
   }
 
   return $ids;
+}
+
+/**
+ * Imports all the exported node files bundled in the SSP
+ *
+ * @throws \Exception
+ */
+function _civihr_import_export_node_files() {
+  NodeHelper::refreshExportFiles();
 }
 
 /**

--- a/civihr.install
+++ b/civihr.install
@@ -327,10 +327,38 @@ function  _civihr_install_install_extensions($extensions, &$context) {
  * @param array $context
  */
 function _civihr_install_ssp(&$context) {
+  _civihr_flush_civicrm_permissions_cache();
   _civihr_enabled_ssp_modules_and_features();
   _civihr_setup_themes();
   _civihr_setup_users();
   _civihr_import_export_node_files();
+}
+
+/**
+ * Flush the CiviCRM permissions cached in memory.
+ *
+ * Civi stores the list of the permissions declared in each of the
+ * installed extensions in a static variable. If an extension is
+ * installed after the cache has been created, any permissions
+ * declared by the extension will not be added to the cache.
+ *
+ * In most of the cases this is not a problem, as usually
+ * extensions are installed in an isolated process (e.g., by clicking
+ * on the Install button in the admin interface, or by running `cv en`),
+ * however, when using this profile with drush, all the commands and tasks
+ * will be executed inside the same process. As a result, all the
+ * permissions added by the CiviHR extensions won't be added to the
+ * cache (because the cache is started when CiviCRM is first installed)
+ * and any code that relies on these permissions will fail.
+ *
+ * Clearing the CiviCRM cache with `System.flush` doesn't clear this
+ * in-memory cache, so the only way to do it is by unsetting the
+ * value in the static array.
+ */
+function _civihr_flush_civicrm_permissions_cache() {
+  if (class_exists('Civi')) {
+    unset(Civi::$statics[CRM_Core_Permission::class]['basicPermissions']);
+  }
 }
 
 /**

--- a/civihr.install
+++ b/civihr.install
@@ -226,7 +226,6 @@ function _civihr_install_civicrm(&$context) {
     throw new \Exception('The CiviCRM database configuration is missing');
   }
 
-  watchdog(WATCHDOG_INFO, 'Installing CiviCRM');
   $civicrm_path = dirname(drupal_get_path('module', 'civicrm'));
 
   require_once implode(DIRECTORY_SEPARATOR, [$civicrm_path, 'CRM', 'Core', 'ClassLoader.php']);
@@ -253,8 +252,6 @@ function _civihr_install_civicrm(&$context) {
 
   $setup->installFiles();
   $setup->installDatabase();
-
-  watchdog(WATCHDOG_INFO, 'CiviCRM Installed');
 }
 
 /**
@@ -319,12 +316,8 @@ function  _civihr_install_install_extensions($extensions, &$context) {
   civicrm_initialize();
   $context['message'] = 'Installed ' . implode(', ', $extensions);
 
-  watchdog(WATCHDOG_INFO, 'Installing ' . implode(', ', $extensions));
-
   civicrm_api3('Extension', 'refresh');
   civicrm_api3('Extension', 'install', ['keys' => $extensions]);
-
-  watchdog(WATCHDOG_INFO, 'Installed ' . implode(', ', $extensions));
 }
 
 /**
@@ -334,19 +327,16 @@ function  _civihr_install_install_extensions($extensions, &$context) {
  * @param array $context
  */
 function _civihr_install_ssp(&$context) {
-  watchdog(WATCHDOG_INFO, 'Install SSP');
   _civihr_enabled_ssp_modules_and_features();
   _civihr_setup_themes();
   _civihr_setup_users();
   _civihr_import_export_node_files();
-  watchdog(WATCHDOG_INFO, 'SSP Installed');
 }
 
 /**
  * Enables all the modules and features used in the SSP
  */
 function _civihr_enabled_ssp_modules_and_features() {
-  watchdog(WATCHDOG_INFO, 'Installing SSP modules and features');
   drupal_flush_all_caches();
 
   $genericModules = [
@@ -388,7 +378,6 @@ function _civihr_enabled_ssp_modules_and_features() {
  * Do any necessary Drupal configuration for the SSP
  */
 function _civihr_ssp_extra_configuration() {
-  watchdog(WATCHDOG_INFO, 'SSP extra configuration');
   variable_set('logintoboggan_login_with_email', 1);
   variable_set('user_pictures', 0);
   variable_set('node_export_reset_path_webform', 0);
@@ -403,7 +392,6 @@ function _civihr_ssp_extra_configuration() {
  * Setup the SSP themes
  */
 function _civihr_setup_themes() {
-  watchdog(WATCHDOG_INFO, 'Setup SSP themes');
   theme_enable(['seven', 'civihr_default_theme']);
   drupal_flush_all_caches();
   variable_set('admin_theme', 'seven');

--- a/civihr.install
+++ b/civihr.install
@@ -202,6 +202,8 @@ function _civihr_install_civihr() {
 
   $operations[] = [ '_civihr_install_ssp', [] ];
 
+  $operations[] = [ '_civihr_extra_civicrm_configuration', [] ];
+
   return [
     'title' => t('Installing CiviHR'),
     'operations' => $operations
@@ -268,7 +270,6 @@ function _civihr_get_extension_install_operations() {
     ],
     [
       'org.civicrm.hrbank',
-      'org.civicrm.hrdemog',
       'org.civicrm.hrjobcontract',
       'com.civicrm.hrjobroles',
       'org.civicrm.hrmed',
@@ -478,6 +479,38 @@ function _civihr_get_roles($roles) {
   }
 
   return $ids;
+}
+
+/**
+ * This is an batch operation used to perform any civicrm-related
+ * necessary configuration while installing CiviHR. It can be used
+ * to set or remove default CiviCRM, options, settings, jobs etc.
+ *
+ * @param $context
+ *
+ * @throws \CiviCRM_API3_Exception
+ */
+function _civihr_extra_civicrm_configuration(&$context) {
+  _civihr_delete_civicrm_name_and_address_profile();
+}
+
+/**
+ * Deletes the "Name and Address" profile in CiviCRM
+ *
+ * @throws \CiviCRM_API3_Exception
+ */
+function _civihr_delete_civicrm_name_and_address_profile() {
+  // We use two separate API calls here because, for some unknown
+  // reason, when a chained call is used the "delete" call results
+  // in an exception saying that the Group cannot be deleted.
+  $result = civicrm_api3('UFGroup', 'getsingle', [
+    'return' => ['id'],
+    'title' => 'Name and address',
+  ]);
+  civicrm_api3('UFGroup', 'delete', [
+    'id' => $result['id'],
+    'debug' => 1,
+  ]);
 }
 
 /**

--- a/civihr.install
+++ b/civihr.install
@@ -296,7 +296,6 @@ function _civihr_get_extension_install_operations() {
       'org.civicrm.hrui',
       'org.civicrm.hrcase',
       'org.civicrm.hrim',
-      'org.civicrm.hrrecruitment',
       'org.civicrm.reqangular',
       'org.civicrm.contactsummary',
       'org.civicrm.shoreditch',

--- a/civihr.install
+++ b/civihr.install
@@ -226,7 +226,7 @@ function _civihr_install_civicrm(&$context) {
     throw new \Exception('The CiviCRM database configuration is missing');
   }
 
-  $civicrm_path = dirname(drupal_get_path('module', 'civicrm'));
+  $civicrm_path = realpath(dirname(drupal_get_path('module', 'civicrm')));
 
   require_once implode(DIRECTORY_SEPARATOR, [$civicrm_path, 'CRM', 'Core', 'ClassLoader.php']);
   CRM_Core_ClassLoader::singleton()->register();

--- a/civihr.install
+++ b/civihr.install
@@ -250,8 +250,19 @@ function _civihr_install_civicrm(&$context) {
     'database' => $civicrmDb['database']
   ];
 
-  $setup->installFiles();
-  $setup->installDatabase();
+  // Depending on how the Drupal installation was performed,
+  // It is possible that the Drupal settings folder will not
+  // be writable. So, before starting the CiviCRM installation,
+  // we need to make sure it's writable so that civicrm-setup
+  // is able to create the civicrm.settings.php file
+  $drupalConfigFolder = conf_path();
+  if (drupal_install_fix_file($drupalConfigFolder, FILE_WRITABLE)) {
+    $setup->installFiles();
+    $setup->installDatabase();
+
+    drupal_install_fix_file($drupalConfigFolder, FILE_NOT_WRITABLE);
+  }
+
 }
 
 /**
@@ -562,7 +573,16 @@ function _civihr_finish_civihr_installation() {
     'value' => $newDatabasesConfiguration,
     'required' => TRUE,
   ];
-  drupal_rewrite_settings($settings);
+
+  // Depending on how the Drupal installation was performed,
+  // it is possible that the settings.php file was made readonly,
+  // so we need first to make sure it's writable before attempting
+  // any updates
+  $settingFile = conf_path() . '/settings.php';
+  if (drupal_install_fix_file($settingFile, FILE_WRITABLE)) {
+    drupal_rewrite_settings($settings);
+    drupal_install_fix_file($settingFile, FILE_NOT_WRITABLE);
+  }
 }
 
 /**

--- a/civihr.make.yml
+++ b/civihr.make.yml
@@ -13,19 +13,21 @@ projects:
     download:
       subdir:
       type: "file"
-      url: "https://download.civicrm.org/civicrm-5.0.0-drupal.tar.gz"
+      url: "https://download.civicrm.org/civicrm-5.3.1-drupal.tar.gz"
+    patch:
+    - "https://github.com/compucorp/civicrm-core/compare/5.3.1...5.3.1-patches.diff"
   civihr_employee_portal:
     subdir: ""
     download:
       type: "git"
       url: "git://github.com/compucorp/civihr-employee-portal.git"
-      tag: "1.7.5"
+      tag: "1.7.9"
   civihr_employee_portal_theme:
     type: "theme"
     download:
       type: "git"
       url: "git://github.com/compucorp/civihr-employee-portal-theme.git"
-      tag: "1.7.5"
+      tag: "1.7.9"
   libraries:
     version: "2.2"
   redirect:
@@ -69,7 +71,7 @@ projects:
   radix_layouts:
     version: "3.3"
   uuid:
-    version: "1.0-alpha6"
+    version: "1.2"
   node_export:
     version: "3.0"
   fancy_login:
@@ -102,7 +104,7 @@ projects:
   logintoboggan:
     version: "1.5"
   yoti:
-    version: "1.4"
+    version: "1.9"
   role_export:
     version: "1.0"
   administerusersbyrole:
@@ -127,6 +129,10 @@ projects:
     version: "1.0"
   roles_for_menu:
     version: "1.1"
+  google_tag:
+    version: "1.3"
+  datalayer:
+    version: "1.1"
   views_slideshow:
     version: "3.9"
   radix:
@@ -140,21 +146,21 @@ libraries:
   civihr:
     download:
       type: "git"
-      url: "git://github.com/civicrm/civihr.git"
-      tag: "1.7.5"
+      url: "git://github.com/compucorp/civihr.git"
+      tag: "1.7.9"
     destination: "modules/civicrm/tools/extensions"
   civihr_tasks:
     download:
       type: "git"
       url: "git://github.com/compucorp/civihr-tasks-assignments.git"
-      tag: "1.7.5"
+      tag: "1.7.9"
     destination: "modules/civicrm/tools/extensions"
   org.civicrm.shoreditch:
-      download:
-        type: "git"
-        url: "git://github.com/civicrm/org.civicrm.shoreditch.git"
-        tag: "v0.1-alpha17"
-      destination: "modules/civicrm/tools/extensions"
+    download:
+      type: "git"
+      url: "git://github.com/civicrm/org.civicrm.shoreditch.git"
+      tag: "v0.1-alpha21"
+    destination: "modules/civicrm/tools/extensions"
   pclzip:
     download:
       type: "git"


### PR DESCRIPTION
## Overview

This PR completes the migration of all the tasks done by the existing installation scripts ([this](https://github.com/compucorp/civihr-installer) and [this](https://github.com/civicrm/civicrm-buildkit/blob/master/app/config/hr17/install.sh)) to the installation profile. 

In practice, this means that now the profile is capable of creating a fully functional CiviHR site, with the same configuration and options as a site created using the existing script.

It also updates the make file to make sure the latest version of all the dependencies will be used.

Finally, a README file is added describing what is the profile and how to use it.

## Technical details

Most of the changes here are basically about copying things from the installation scripts to the profile. Any important details is either in the commit messages or in comments in the code. Please make sure of checking those.

A few changes have been made in other repositories to support the profile installation. You can find these changes in these PRs:

- PCHR-3681: Remove unnecessary param in calls to CRM_Utils_Request::retrieve(): https://github.com/compucorp/civihr/pull/2825
- PCHR-3681: Fixes for the CiviHR installation profile: https://github.com/compucorp/civihr-employee-portal/pull/537
- PCHR-3681: Remove hardcoded paths: https://github.com/compucorp/civihr-employee-portal-theme/pull/380